### PR TITLE
Adjust snake board size and push changes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ function useKeyboardDirection(initial = [1, 0]) {
 }
 
 // === Game logic hook without useFrame ===
-function useSnakeGame({ size = 15, stepTime = 0.2, running, onGameOver }) {
+function useSnakeGame({ size = 20, stepTime = 0.2, running, onGameOver }) {
   const [snake, setSnake] = useState(() => [[0, 0], [-1, 0], [-2, 0]]);
   const [dir, setDir] = useKeyboardDirection([1, 0]);
   const [food, setFood] = useState([3, 0]);
@@ -201,7 +201,7 @@ function Ground({ size }) {
 // === Main Scene ===
 function Scene() {
   const [running, setRunning] = useState(true);
-  const [size, setSize] = useState(12);
+  const [size, setSize] = useState(20);
   const [speed, setSpeed] = useState(0.18);
   const [gameOver, setGameOver] = useState(false);
   const gameState = useSnakeGame({
@@ -230,7 +230,7 @@ function Scene() {
         <button className="hud-btn" onClick={() => { gameState.reset(); setGameOver(false); setRunning(true); }}>Reset</button>
       </div>
       {gameState.scoreboard.length > 0 && (
-        <div className="absolute bottom-4 left-3 hud">
+        <div className="absolute bottom-20 left-3 hud">
           <div className="font-bold">Scoreboard:</div>
           {gameState.scoreboard.map((s, i) => (
             <div key={i}>{s.name || '???'} — {s.score}</div>


### PR DESCRIPTION
Increase snake board size and adjust scoreboard position to provide more gameplay area and prevent overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-14aaf8d7-2f39-4a2c-af6b-7b6c6b1d341e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14aaf8d7-2f39-4a2c-af6b-7b6c6b1d341e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

